### PR TITLE
add `hopper` support

### DIFF
--- a/homedecor_common/furnaces.lua
+++ b/homedecor_common/furnaces.lua
@@ -148,7 +148,8 @@ function homedecor.register_furnace(name, furnacedef)
 		can_dig = furnace_can_dig,
 		allow_metadata_inventory_put = furnace_allow_put,
 		allow_metadata_inventory_move = furnace_allow_move,
-		inventory = { lockable = true }
+		inventory = { lockable = true },
+		is_furnace = true
 	}
 
 	local def_active = {
@@ -162,7 +163,8 @@ function homedecor.register_furnace(name, furnacedef)
 		can_dig = furnace_can_dig,
 		allow_metadata_inventory_put = furnace_allow_put,
 		allow_metadata_inventory_move = furnace_allow_move,
-		inventory = { lockable = true }
+		inventory = { lockable = true },
+		is_furnace = true
 	}
 
 	if furnacedef.extra_nodedef_fields then

--- a/homedecor_common/mod.conf
+++ b/homedecor_common/mod.conf
@@ -1,4 +1,4 @@
 name = homedecor_common
 description = Homedecor mod: common
 depends = default, creative
-optional_depends = screwdriver
+optional_depends = screwdriver, hopper

--- a/homedecor_common/registration.lua
+++ b/homedecor_common/registration.lua
@@ -6,6 +6,8 @@ local placeholder_node = "homedecor:expansion_placeholder"
 function homedecor.register(name, original_def)
 	local def = table.copy(original_def)
 
+	def.is_furnace = nil
+
 	def.drawtype = def.drawtype
 		or (def.mesh and "mesh")
 		or (def.node_box and "nodebox")


### PR DESCRIPTION
adds `hopper`support for nodes with inventory:
- cardboard_box
- cardboard_box_big
- desk
- desk_locked (*)
- filing_cabinet
- filing_cabinet_locked (*)
- kitchen_cabinet_colorable
- kitchen_cabinet_colorable_granite
- kitchen_cabinet_colorable_granite_locked (*)
- kitchen_cabinet_colorable_half
- kitchen_cabinet_colorable_half_locked (*)
- kitchen_cabinet_colorable_locked (*)
- kitchen_cabinet_colorable_marble
- kitchen_cabinet_colorable_marble_locked (*)
- kitchen_cabinet_colorable_steel
- kitchen_cabinet_colorable_steel_locked (*)
- kitchen_cabinet_colorable_with_drawers
- kitchen_cabinet_colorable_with_drawers_granite
- kitchen_cabinet_colorable_with_drawers_granite_locked (*)
- kitchen_cabinet_colorable_with_drawers_locked (*)
- kitchen_cabinet_colorable_with_drawers_marble
- kitchen_cabinet_colorable_with_drawers_marble_locked (*)
- kitchen_cabinet_colorable_with_drawers_steel
- kitchen_cabinet_colorable_with_drawers_steel_locked (*)
- kitchen_cabinet_colorable_with_sink
- kitchen_cabinet_colorable_with_sink_locked (*)
- kitchen_cabinet_colored
- kitchen_cabinet_colored_granite
- kitchen_cabinet_colored_granite_locked (*)
- kitchen_cabinet_colored_half
- kitchen_cabinet_colored_half_locked (*)
- kitchen_cabinet_colored_locked (*)
- kitchen_cabinet_colored_marble
- kitchen_cabinet_colored_marble_locked (*)
- kitchen_cabinet_colored_steel
- kitchen_cabinet_colored_steel_locked (*)
- kitchen_cabinet_colored_with_drawers
- kitchen_cabinet_colored_with_drawers_granite
- kitchen_cabinet_colored_with_drawers_granite_locked (*)
- kitchen_cabinet_colored_with_drawers_locked (*)
- kitchen_cabinet_colored_with_drawers_marble
- kitchen_cabinet_colored_with_drawers_marble_locked (*)
- kitchen_cabinet_colored_with_drawers_steel
- kitchen_cabinet_colored_with_drawers_steel_locked (*)
- kitchen_cabinet_colored_with_sink
- kitchen_cabinet_colored_with_sink_locked (*)
- medicine_cabinet
- microwave_oven
- microwave_oven_active
- microwave_oven_active_locked (*)
- microwave_oven_locked (*)
- nightstand_mahogany_one_drawer
- nightstand_mahogany_one_drawer_locked (*)
- nightstand_mahogany_two_drawers
- nightstand_mahogany_two_drawers_locked (*)
- nightstand_oak_one_drawer
- nightstand_oak_one_drawer_locked (*)
- nightstand_oak_two_drawers
- nightstand_oak_two_drawers_locked (*)
- oven
- oven_active
- oven_active_locked (*)
- oven_locked (*)
- oven_steel
- oven_steel_active
- oven_steel_active_locked (*)
- oven_steel_locked (*)
- refrigerator_steel
- refrigerator_steel_locked (*)
- refrigerator_white
- refrigerator_white_locked (*)
- trash_can_green_open

Tested with minetest-5.4.1 and
- TenPlus1 Version 1.6 https://notabug.org/TenPlus1/hopper/src/bb384567202cf6f432aa9d1b8666f6eb4ebcdaf1
- TenPlus1 Version 1.8 https://notabug.org/TenPlus1/hopper/src/0797ee5c96534b905fe280bb265239519be8e2d3
- minetest-mods Version 1.7 https://github.com/minetest-mods/hopper/tree/6ac1b61

Nodes with (*) are excluded in TenPlus1's Version < 1.8 (because here the owner has not been checked yet)