### PR TITLE
fix almost all warning spam

### DIFF
--- a/homedecor_bathroom/init.lua
+++ b/homedecor_bathroom/init.lua
@@ -171,6 +171,7 @@ homedecor.register("toilet_open", {
 	selection_box = toilet_sbox,
 	collision_box = toilet_cbox,
 	drop = "homedecor:toilet",
+	use_texture_alpha = "blend",
 	groups = {cracky=3},
 	sounds = default.node_sound_stone_defaults(),
 	on_rightclick = function(pos, node, clicker, itemstack, pointed_thing)
@@ -231,6 +232,7 @@ homedecor.register("sink", {
 		"building_blocks_marble.png",
 		"default_water.png"
 	},
+	use_texture_alpha = "blend",
 	inventory_image="homedecor_bathroom_sink_inv.png",
 	selection_box = sink_sbox,
 	collision_box = sink_cbox,

--- a/homedecor_doors_and_gates/init.lua
+++ b/homedecor_doors_and_gates/init.lua
@@ -102,7 +102,7 @@ local function generate_door(def)
 					local door = doors.get(pos)
 					if door then door:close() end
 				end,
-				rules = mesecon and mesecon.rules.pplate or nil
+				rules = minetest.global_exists("mesecon") and mesecon.rules.pplate or nil
 			}
 		},
 	}

--- a/homedecor_kitchen/init.lua
+++ b/homedecor_kitchen/init.lua
@@ -86,6 +86,7 @@ homedecor.register_furnace("microwave_oven", {
 	output_width = 2,
 	cook_speed = 1.5,
 	extra_nodedef_fields = {
+		use_texture_alpha = "clip",
 		node_box = {
 			type = "fixed",
 			fixed = { -0.5, -0.5, -0.125, 0.5, 0.125, 0.5 },
@@ -178,7 +179,7 @@ for _, mat in ipairs(counter_materials) do
 			.."{homedecor_kitchen_cabinet_front.png"
 			.."{"..ic_cabinet_sides,
 		mesh = "homedecor_kitchen_cabinet.obj",
-		paramtype2 = "wallmounted",
+		paramtype2 = "colorwallmounted",
 		palette = "unifieddyes_palette_colorwallmounted.png",
 		airbrush_replacement_node = "homedecor:kitchen_cabinet_colored"..material,
 		place_param2 = 0,
@@ -238,7 +239,7 @@ for _, mat in ipairs(counter_materials) do
 			.."{homedecor_kitchen_cabinet_front_with_drawers.png"
 			.."{"..ic_cabinet_sides,
 		mesh = "homedecor_kitchen_cabinet.obj",
-		paramtype2 = "wallmounted",
+		paramtype2 = "colorwallmounted",
 		palette = "unifieddyes_palette_colorwallmounted.png",
 		airbrush_replacement_node = "homedecor:kitchen_cabinet_colored_with_drawers"..material,
 		groups = { snappy = 3, ud_param2_colorable = 1},
@@ -300,7 +301,7 @@ homedecor.register("kitchen_cabinet_colorable_half", {
 		'homedecor_kitchen_cabinet_front_half.png^homedecor_kitchen_cabinet_half_bevel.png'
 	},
 	mesh = "homedecor_kitchen_cabinet_half.obj",
-	paramtype2 = "wallmounted",
+	paramtype2 = "colorwallmounted",
 	palette = "unifieddyes_palette_colorwallmounted.png",
 	airbrush_replacement_node = "homedecor:kitchen_cabinet_colored_half",
 	place_param2 = 0,
@@ -363,7 +364,7 @@ homedecor.register("kitchen_cabinet_colorable_with_sink", {
 			.."{homedecor_kitchen_sink_top.png"
 			.."{homedecor_kitchen_cabinet_front.png"
 			.."{"..ic_cabinet_sides,
-	paramtype2 = "wallmounted",
+	paramtype2 = "colorwallmounted",
 	palette = "unifieddyes_palette_colorwallmounted.png",
 	airbrush_replacement_node = "homedecor:kitchen_cabinet_colored_with_sink",
 	place_param2 = 0,

--- a/homedecor_lighting/init.lua
+++ b/homedecor_lighting/init.lua
@@ -263,7 +263,7 @@ for brightness_level = 0, 14 do
 		description = S("Thick Glowlight"),
 		tiles = tiles,
 		overlay_tiles = overlay,
-		use_texture_alpha = true,
+		use_texture_alpha = "blend",
 		drawtype = "nodebox",
 		paramtype = "light",
 		paramtype2 = "colorwallmounted",
@@ -329,7 +329,7 @@ for brightness_level = 0, 14 do
 		description = S("Thin Glowlight"),
 		tiles = tiles,
 		overlay_tiles = overlay,
-		use_texture_alpha = true,
+		use_texture_alpha = "blend",
 		drawtype = "nodebox",
 		paramtype = "light",
 		paramtype2 = "colorwallmounted",
@@ -396,7 +396,7 @@ for brightness_level = 0, 14 do
 		description = S("Small Glowlight Cube"),
 		tiles = tiles,
 		overlay_tiles = overlay,
-		use_texture_alpha = true,
+		use_texture_alpha = "blend",
 		paramtype = "light",
 		paramtype2 = "colorwallmounted",
 		drawtype = "nodebox",
@@ -448,7 +448,7 @@ for brightness_level = 0, 14 do
 			"default_gold_block.png",
 			lighttex
 		},
-		use_texture_alpha = true,
+		use_texture_alpha = "blend",
 		light_source = brightness_level,
 		sunlight_propagates = true,
 		groups = {cracky=3, oddly_breakable_by_hand=3, not_in_creative_inventory = nici},
@@ -473,7 +473,7 @@ for brightness_level = 0, 14 do
 		description = S("Ground Lantern/Light"),
 		mesh = "homedecor_ground_lantern.obj",
 		tiles = { gen_ls_tex_yellow, "homedecor_generic_metal_wrought_iron.png" },
-		use_texture_alpha = true,
+		use_texture_alpha = "blend",
 		inventory_image = "homedecor_ground_lantern_inv.png",
 		wield_image = "homedecor_ground_lantern_inv.png",
 		groups = {snappy=3, not_in_creative_inventory = nici},
@@ -500,7 +500,7 @@ for brightness_level = 0, 14 do
 		description = S("Hanging Lantern/Light"),
 		mesh = "homedecor_hanging_lantern.obj",
 		tiles = { "homedecor_generic_metal_wrought_iron.png", gen_ls_tex_yellow },
-		use_texture_alpha = true,
+		use_texture_alpha = "blend",
 		inventory_image = "homedecor_hanging_lantern_inv.png",
 		wield_image = "homedecor_hanging_lantern_inv.png",
 		groups = {snappy=3, not_in_creative_inventory = nici},
@@ -527,7 +527,7 @@ for brightness_level = 0, 14 do
 		drawtype = "mesh",
 		mesh = "homedecor_ceiling_lantern.obj",
 		tiles = { gen_ls_tex_yellow, "homedecor_generic_metal_wrought_iron.png" },
-		use_texture_alpha = true,
+		use_texture_alpha = "blend",
 		inventory_image = "homedecor_ceiling_lantern_inv.png",
 		description = S("Ceiling Lantern/Light"),
 		groups = {snappy=3, not_in_creative_inventory = nici},
@@ -549,6 +549,7 @@ for brightness_level = 0, 14 do
 		homedecor.register("lattice_lantern_large_"..brightness_level, {
 			description = S("Lattice lantern/Light (large)"),
 			tiles = { gen_ls_tex_yellow.."^homedecor_lattice_lantern_large_overlay.png" },
+			use_texture_alpha = "clip",
 			groups = { snappy = 3, not_in_creative_inventory = nici },
 			light_source = brightness_level,
 			sounds = default.node_sound_glass_defaults(),
@@ -590,6 +591,7 @@ for brightness_level = 0, 14 do
 			type = "fixed",
 			fixed = { -0.25, -0.5, -0.25, 0.25, 0, 0.25 }
 		},
+		use_texture_alpha = "clip",
 		groups = { snappy = 3, not_in_creative_inventory = nici },
 		light_source = brightness_level,
 		sounds = default.node_sound_glass_defaults(),
@@ -792,7 +794,7 @@ for _, light_brightn_name in ipairs({"off", "on"}) do
 			fixed = { -0.1875, -0.5, -0.1875, 0.1875, 0, 0.1875 }
 		},
 		walkable = false,
-		use_texture_alpha = true,
+		use_texture_alpha = "blend",
 		light_source = onflag and (default.LIGHT_MAX - 5) or nil,
 		sunlight_propagates = true,
 		groups = {cracky=3, oddly_breakable_by_hand=3, not_in_creative_inventory = nici},
@@ -916,7 +918,7 @@ for _, light_brightn_name in ipairs({"off", "on"}) do
 			gen_ls_tex_yellow,
 			"homedecor_generic_metal_wrought_iron.png"
 		},
-		use_texture_alpha = true,
+		use_texture_alpha = "blend",
 		inventory_image = "homedecor_wall_lamp_inv.png",
 		groups = {snappy=3, not_in_creative_inventory = nici},
 		light_source = onflag and (default.LIGHT_MAX - 3) or nil,
@@ -954,6 +956,7 @@ homedecor.register("candle", {
 	inventory_image = "homedecor_candle_inv.png",
 	selection_box = tc_cbox,
 	walkable = false,
+	use_texture_alpha = "clip",
 	groups = { snappy = 3 },
 	light_source = default.LIGHT_MAX-4,
 })
@@ -975,6 +978,7 @@ homedecor.register("candle_thin", {
 	inventory_image = "homedecor_candle_thin_inv.png",
 	selection_box = c_cbox,
 	walkable = false,
+	use_texture_alpha = "clip",
 	groups = { snappy = 3 },
 	light_source = default.LIGHT_MAX-4,
 })
@@ -997,6 +1001,7 @@ homedecor.register("candlestick_wrought_iron", {
 	inventory_image = "homedecor_candlestick_wrought_iron_inv.png",
 	selection_box = cs_cbox,
 	walkable = false,
+	use_texture_alpha = "clip",
 	groups = { snappy = 3 },
 	light_source = default.LIGHT_MAX-4,
 })
@@ -1012,6 +1017,7 @@ homedecor.register("candlestick_brass", {
 	inventory_image = "homedecor_candlestick_brass_inv.png",
 	selection_box = cs_cbox,
 	walkable = false,
+	use_texture_alpha = "clip",
 	groups = { snappy = 3 },
 	light_source = default.LIGHT_MAX-4,
 })
@@ -1031,6 +1037,7 @@ homedecor.register("wall_sconce", {
 		fixed = { -0.1875, -0.25, 0.3125, 0.1875, 0.25, 0.5 }
 	},
 	walkable = false,
+	use_texture_alpha = "clip",
 	groups = { snappy = 3 },
 	light_source = default.LIGHT_MAX-4,
 })
@@ -1053,7 +1060,7 @@ homedecor.register("oil_lamp", {
 		{ name = "homedecor_generic_metal.png", color = 0xffa00000 },
 		"homedecor_oil_lamp_glass.png",
 	},
-	use_texture_alpha = true,
+	use_texture_alpha = "blend",
 	inventory_image = "homedecor_oil_lamp_inv.png",
 	selection_box = ol_cbox,
 	walkable = false,
@@ -1132,6 +1139,7 @@ minetest.register_node(":homedecor:chandelier_steel", {
 	},
 	drawtype = "mesh",
 	mesh = "homedecor_chandelier.obj",
+	use_texture_alpha = "clip",
 	groups = {cracky=3},
 	sounds =  default.node_sound_stone_defaults(),
 })
@@ -1158,6 +1166,7 @@ minetest.register_node(":homedecor:chandelier_brass", {
 	},
 	drawtype = "mesh",
 	mesh = "homedecor_chandelier.obj",
+	use_texture_alpha = "clip",
 	groups = {cracky=3},
 	sounds =  default.node_sound_stone_defaults(),
 })
@@ -1186,6 +1195,7 @@ homedecor.register("torch_wall", {
 		type = "fixed",
 		fixed = { -0.15, -0.45, 0.15, 0.15,0.35, 0.5 },
 	},
+	use_texture_alpha = "clip",
 	groups = {cracky=3},
 })
 

--- a/homedecor_misc/init.lua
+++ b/homedecor_misc/init.lua
@@ -112,6 +112,7 @@ for _, f in ipairs(flowers_list) do
 			"flowers_"..flower..".png"
 		},
 		walkable = false,
+		use_texture_alpha = "clip",
 		groups = {snappy = 3},
 		sounds = default.node_sound_glass_defaults(),
 		selection_box = {
@@ -183,7 +184,7 @@ homedecor.register("fishtank", {
 		"homedecor_fishtank_water_top.png",
 		"homedecor_fishtank_sides.png",
 	},
-	use_texture_alpha = true,
+	use_texture_alpha = "blend",
 	selection_box = ft_cbox,
 	collision_box = ft_cbox,
 	groups = {cracky=3,oddly_breakable_by_hand=3},
@@ -206,7 +207,7 @@ homedecor.register("fishtank_lighted", {
 		"homedecor_fishtank_sides_lighted.png",
 	},
 	light_source = default.LIGHT_MAX-4,
-	use_texture_alpha = true,
+	use_texture_alpha = "blend",
 	selection_box = ft_cbox,
 	collision_box = ft_cbox,
 	groups = {cracky=3,oddly_breakable_by_hand=3,not_in_creative_inventory=1},
@@ -225,6 +226,7 @@ homedecor.register("cardboard_box_big", {
 		'homedecor_cardbox_big_tb.png',
 		'homedecor_cardbox_big_sides.png',
 	},
+	use_texture_alpha = "clip",
 	groups = { snappy = 3 },
 	infotext=S("Cardboard box"),
 	inventory = {
@@ -245,6 +247,7 @@ homedecor.register("cardboard_box", {
 			{-0.3125, -0.5, -0.3125, 0.3125, 0, 0.3125},
 		}
 	},
+	use_texture_alpha = "clip",
 	groups = { snappy = 3 },
 	infotext=S("Cardboard box"),
 	inventory = {
@@ -366,6 +369,7 @@ homedecor.register("skateboard", {
 	tiles = { "homedecor_skateboard.png" },
 	inventory_image = "homedecor_skateboard_inv.png",
 	description = S("Skateboard"),
+	use_texture_alpha = "clip",
 	groups = {snappy=3},
 	selection_box = skate_cbox,
 	walkable = false,

--- a/homedecor_windows_and_treatments/init.lua
+++ b/homedecor_windows_and_treatments/init.lua
@@ -12,7 +12,7 @@ homedecor.register("window_quartered", {
 		"homedecor_window_quartered.png",
 		"homedecor_window_quartered.png"
 	},
-	use_texture_alpha = true,
+	use_texture_alpha = "blend",
 	groups = {snappy=3},
 	sounds = default.node_sound_glass_defaults(),
 	node_box = {
@@ -43,7 +43,7 @@ homedecor.register("window_plain", {
 		"homedecor_window_frame.png",
 		"homedecor_window_frame.png"
 	},
-	use_texture_alpha = true,
+	use_texture_alpha = "blend",
 	groups = {snappy=3},
 	sounds = default.node_sound_glass_defaults(),
 	node_box = {
@@ -105,7 +105,7 @@ minetest.register_node(":homedecor:curtain_closed", {
 	tiles = { "homedecor_curtain.png" },
 	inventory_image = "homedecor_curtain.png",
 	drawtype = 'signlike',
-	use_texture_alpha = true,
+	use_texture_alpha = "blend",
 	walkable = false,
 	groups = { snappy = 3, ud_param2_colorable = 1, not_in_creative_inventory=1 },
 	sounds = default.node_sound_leaves_defaults(),
@@ -128,7 +128,7 @@ minetest.register_node(":homedecor:curtain_open", {
 	tiles = { "homedecor_curtain_open.png" },
 	inventory_image = "homedecor_curtain_open.png",
 	drawtype = 'signlike',
-	use_texture_alpha = true,
+	use_texture_alpha = "blend",
 	walkable = false,
 	groups = { snappy = 3, ud_param2_colorable = 1 },
 	sounds = default.node_sound_leaves_defaults(),
@@ -179,6 +179,7 @@ homedecor.register("window_flowerbox", {
 	},
 	inventory_image = "homedecor_flowerbox_inv.png",
 	sounds = default.node_sound_stone_defaults(),
+	use_texture_alpha = "clip",
 	groups = { snappy = 3 },
 	node_box = {
 		type = "fixed",
@@ -195,7 +196,7 @@ homedecor.register("stained_glass", {
 	tiles = {"homedecor_stained_glass.png"},
 	inventory_image = "homedecor_stained_glass.png",
 	groups = {snappy=3},
-	use_texture_alpha = true,
+	use_texture_alpha = "blend",
 	light_source = 3,
 	sounds = default.node_sound_glass_defaults(),
 	node_box = {

--- a/lavalamp/init.lua
+++ b/lavalamp/init.lua
@@ -22,7 +22,7 @@ minetest.register_node("lavalamp:lavalamp", {
 			},
 		},
 	},
-	use_texture_alpha = true,
+	use_texture_alpha = "blend",
 	inventory_image = "lavalamp_lamp_inv.png",
 	paramtype = "light",
 	paramtype2 = "color",


### PR DESCRIPTION
this fixes almost all the warning spam from homedecor, with the exception of the register aliases from homedecor lighting. this follows earlier PR https://github.com/mt-mods/homedecor_modpack/pull/20 and issue https://github.com/mt-mods/homedecor_modpack/issues/15