### PR TITLE
add a global `.luacheckrc`

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,0 +1,11 @@
+
+name: luacheck
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: Roang-zero1/factorio-mod-luacheck@master
+        with:
+          luacheckrc_url: ""

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,38 @@
+unused_args = false
+
+globals = {
+	"homedecor",
+    "homedecor_lighting",
+    "homedecor_windows_and_treatments",
+    "homedecor_roofing",
+    "homedecor_misc",
+    "homedecor_exterior",
+    "homedecor_electrical",
+    "lavalamp",
+    "lrfurn",
+    "signs_lib",
+
+    -- mod-deps
+    "armor"
+}
+
+read_globals = {
+	"minetest", "core",
+	"vector", "ItemStack",
+
+	-- Stdlib
+	string = {fields = {"split", "trim"}},
+	table = {fields = {"copy", "getn"}},
+
+    -- mod-deps
+    "default",
+    "unifieddyes",
+    "player_api",
+    "screwdriver",
+    "hopper",
+    "mesecon",
+    "skins",
+    "homedecor_doors_and_gates",
+    "stairsplus",
+    "creative"
+}

--- a/homedecor_kitchen/init.lua
+++ b/homedecor_kitchen/init.lua
@@ -283,8 +283,10 @@ for _, mat in ipairs(counter_materials) do
 		end
 	})
 
-	homedecor.kitchen_convert_nodes[#homedecor.kitchen_convert_nodes + 1] = "homedecor:kitchen_cabinet"..material
-	homedecor.kitchen_convert_nodes[#homedecor.kitchen_convert_nodes + 1] = "homedecor:kitchen_cabinet"..material.."_locked"
+	homedecor.kitchen_convert_nodes[#homedecor.kitchen_convert_nodes + 1] =
+		"homedecor:kitchen_cabinet"..material
+	homedecor.kitchen_convert_nodes[#homedecor.kitchen_convert_nodes + 1] =
+		"homedecor:kitchen_cabinet"..material.."_locked"
 
 end
 

--- a/homedecor_tables/misc.lua
+++ b/homedecor_tables/misc.lua
@@ -19,7 +19,7 @@ local tabletop_materials = {
 	}
 }
 
-leg_materials = {
+local leg_materials = {
 	{ "brass",          S("brass") },
 	{ "wrought_iron",   S("wrought iron") },
 	{ "wood",           S("wood") }
@@ -55,7 +55,7 @@ local tables_cbox = {
 }
 
 for i, mat in ipairs(tabletop_materials) do
-	local m, small_s, small_r, large = unpack(mat)
+	local m = unpack(mat)
 	local s
 
 	if m == "glass" then
@@ -101,7 +101,7 @@ for i, mat in ipairs(tabletop_materials) do
 		})
 
 		for _, l in ipairs(leg_materials) do
-			local leg_mat, desc = unpack(l)
+			local leg_mat = unpack(l)
 
 			homedecor.register(string.format("%s_table_%s_with_%s_legs", m, shape, leg_mat), {
 				description = string.format("%s %s table with %s legs", shape, m, leg_mat),

--- a/homedecor_wardrobe/init.lua
+++ b/homedecor_wardrobe/init.lua
@@ -1,5 +1,5 @@
 local S = minetest.get_translator("homedecor_wardrobe")
-modpath = minetest.get_modpath("homedecor_wardrobe")
+local modpath = minetest.get_modpath("homedecor_wardrobe")
 
 local wd_cbox = {type = "fixed", fixed = {-0.5, -0.5, -0.5, 0.5, 1.5, 0.5}}
 


### PR DESCRIPTION
i wanted to add a luacheck-workflow + .luacheckrc to the modpack but realized somewhere in the end that there were already some `.luacheckrc` files in the mod-folders itself :facepalm: 

Just placing this here until:
* Someone wants to convert all rc-files to one, or
* Someone adds a proper luacheck-workflow for the various mod-folders