### PR TITLE
remove weird, redundant loop

### DIFF
--- a/building_blocks/alias.lua
+++ b/building_blocks/alias.lua
@@ -8,16 +8,9 @@ if minetest.get_modpath("moreblocks") or minetest.get_modpath("stairs") then
 end
 
 if minetest.get_modpath("moreblocks") then
+	minetest.register_alias_force("moreblocks:tar", "building_blocks:Tar")
 	stairsplus:register_alias_all("building_blocks", "tar", "building_blocks", "Tar")
 	stairsplus:register_alias_all("building_blocks", "marble", "building_blocks", "Marble")
-	for _, i in ipairs(stairsplus.shapes_list) do
-		local class = i[1]
-		local cut = i[2]
-		minetest.unregister_item("moreblocks:"..class.."tar"..cut)
-		minetest.register_alias("moreblocks:"..class.."tar"..cut, "building_blocks:"..class.."tar"..cut)
-	end
-	minetest.unregister_item("moreblocks:tar")
-	minetest.register_alias("moreblocks:tar", "building_blocks:Tar")
 	stairsplus:register_alias_all("moreblocks", "tar", "building_blocks", "Tar")
 
 	if minetest.get_modpath("gloopblocks") then


### PR DESCRIPTION
the removed loop was doing the same thing as the `stairsplus:register_alias_all("moreblocks", "tar", "building_blocks", "Tar")` line below, but causing a crash when using the (not yet pulled) new stairsplus API https://github.com/minetest-mods/moreblocks/pull/191