### PR TITLE
remove double crafting recipes

### DIFF
--- a/homedecor_climate_control/init.lua
+++ b/homedecor_climate_control/init.lua
@@ -135,13 +135,6 @@ homedecor.register("ceiling_fan", {
 				{ "homedecor:fan_blades" },
 				{ "homedecor:glowlight_small_cube" }
 			}
-		},
-		{
-			recipe = {
-				{ "basic_materials:motor" },
-				{ "homedecor:fan_blades" },
-				{ "homedecor:glowlight_small_cube" }
-			}
 		}
 	}
 })

--- a/homedecor_exterior/init.lua
+++ b/homedecor_exterior/init.lua
@@ -107,14 +107,6 @@ homedecor.register("stonepath", {
 		{
 			output = "homedecor:stonepath 16",
 			recipe = {
-				{ "slab_stone","","slab_stone" },
-				{ "","slab_stone","" },
-				{ "slab_stone","","slab_stone" }
-			},
-		},
-		{
-			output = "homedecor:stonepath 16",
-			recipe = {
 				{ "moreblocks:slab_stone","","moreblocks:slab_stone" },
 				{ "","moreblocks:slab_stone","" },
 				{ "moreblocks:slab_stone","","moreblocks:slab_stone" }
@@ -248,13 +240,6 @@ homedecor.register("swing", {
 		end
 	end,
 	crafts = {
-		{
-			recipe = {
-				{ "string","","string" },
-				{ "string","","string" },
-				{ "string","slab_wood","string" }
-			},
-		},
 		{
 			recipe = {
 				{ "string","","string" },

--- a/homedecor_kitchen/init.lua
+++ b/homedecor_kitchen/init.lua
@@ -680,23 +680,7 @@ minetest.register_craft( {
 minetest.register_craft( {
     output = "homedecor:dishwasher_wood",
     recipe = {
-		{ "stairs:slab_wood" },
-		{ "homedecor:dishwasher" },
-    },
-})
-
-minetest.register_craft( {
-    output = "homedecor:dishwasher_wood",
-    recipe = {
 		{ "moreblocks:slab_wood" },
-		{ "homedecor:dishwasher" },
-    },
-})
-
-minetest.register_craft( {
-    output = "homedecor:dishwasher_wood",
-    recipe = {
-		{ "moreblocks:slab_wood_1" },
 		{ "homedecor:dishwasher" },
     },
 })

--- a/homedecor_laundry/init.lua
+++ b/homedecor_laundry/init.lua
@@ -27,13 +27,6 @@ homedecor.register("washing_machine", {
 				{ "steel_ingot", "water_bucket", "steel_ingot" },
 				{ "steel_ingot", "basic_materials:motor", "steel_ingot" }
 			},
-		},
-		{
-			recipe = {
-				{ "steel_ingot", "steel_ingot", "basic_materials:ic" },
-				{ "steel_ingot", "water_bucket", "steel_ingot" },
-				{ "steel_ingot", "basic_materials:motor", "steel_ingot" }
-			},
 		}
 	}
 })
@@ -58,13 +51,6 @@ homedecor.register("dryer", {
 	selection_box = { type = "regular" },
 	groups = { snappy = 3, dig_stone=3 },
 	crafts = {
-		{
-			recipe = {
-				{ "steel_ingot", "steel_ingot", "basic_materials:ic" },
-				{ "steel_ingot", "empty_bucket", "basic_materials:motor" },
-				{ "steel_ingot", "basic_materials:heating_element", "steel_ingot" }
-			},
-		},
 		{
 			recipe = {
 				{ "steel_ingot", "steel_ingot", "basic_materials:ic" },

--- a/homedecor_office/init.lua
+++ b/homedecor_office/init.lua
@@ -55,13 +55,6 @@ homedecor.register("desk", {
 	crafts = {
 		{
 			recipe = {
-				{ "slab_wood", "slab_wood", "slab_wood" },
-				{ "homedecor:drawer_small", "group:wood", "group:wood" },
-				{ "homedecor:drawer_small", "", "group:wood" },
-			},
-		},
-		{
-			recipe = {
 				{ "moreblocks:slab_wood", "moreblocks:slab_wood", "moreblocks:slab_wood" },
 				{ "homedecor:drawer_small", "group:wood", "group:wood" },
 				{ "homedecor:drawer_small", "", "group:wood" },
@@ -93,13 +86,6 @@ homedecor.register("desk_globe", {
 		key = "node_sound_wood_defaults",
 	},
 	crafts = {
-		{
-			recipe = {
-				{ "group:stick", "basic_materials:plastic_sheet", "dye_green" },
-				{ "group:stick", "basic_materials:plastic_sheet", "basic_materials:plastic_sheet" },
-				{ "group:stick", "slab_wood", "dye_blue" }
-			},
-		},
 		{
 			recipe = {
 				{ "group:stick", "basic_materials:plastic_sheet", "dye_green" },

--- a/homedecor_seating/armchairs.lua
+++ b/homedecor_seating/armchairs.lua
@@ -71,15 +71,6 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	output = "lrfurn:armchair",
-	recipe = {
-		{"wool:white", "", "", },
-		{"moreblocks:slab_wood", "", "", },
-		{"group:stick", "", "", }
-	}
-})
-
 unifieddyes.register_color_craft({
 	output = "lrfurn:armchair",
 	palette = "wallmounted",

--- a/homedecor_seating/longsofas.lua
+++ b/homedecor_seating/longsofas.lua
@@ -57,15 +57,6 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	output = "lrfurn:longsofa",
-	recipe = {
-		{homedecor.materials.wool_white, homedecor.materials.wool_white, homedecor.materials.wool_white, },
-		{"moreblocks:slab_wood", "moreblocks:slab_wood", "moreblocks:slab_wood", },
-		{"group:stick", "group:stick", "group:stick", }
-	}
-})
-
 unifieddyes.register_color_craft({
 	output = "lrfurn:longsofa",
 	palette = "wallmounted",

--- a/homedecor_seating/misc.lua
+++ b/homedecor_seating/misc.lua
@@ -242,30 +242,12 @@ minetest.register_craft( {
 })
 
 minetest.register_craft( {
-        output = "homedecor:bench_large_2_left",
-        recipe = {
-			{ "homedecor:shutter_oak", "homedecor:shutter_oak", "homedecor:shutter_oak" },
-			{ "group:wood", "group:wood", "group:wood" },
-			{ "moreblocks:slab_wood", "", "moreblocks:slab_wood" }
-        },
-})
-
-minetest.register_craft( {
         output = "homedecor:simple_bench",
         recipe = {
 			{ homedecor.materials.slab_wood, homedecor.materials.slab_wood, homedecor.materials.slab_wood },
 			{ homedecor.materials.slab_wood, "", homedecor.materials.slab_wood }
         },
 })
-
-minetest.register_craft( {
-        output = "homedecor:simple_bench",
-        recipe = {
-			{ "moreblocks:slab_wood", "moreblocks:slab_wood", "moreblocks:slab_wood" },
-			{ "moreblocks:slab_wood", "", "moreblocks:slab_wood" }
-        },
-})
-
 
 minetest.register_craft({
 	output = "homedecor:deckchair",

--- a/homedecor_seating/sofas.lua
+++ b/homedecor_seating/sofas.lua
@@ -57,15 +57,6 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	output = "lrfurn:sofa",
-	recipe = {
-		{homedecor.materials.wool_white, homedecor.materials.wool_white, "", },
-		{"moreblocks:slab_wood", "moreblocks:slab_wood", "", },
-		{"group:stick", "group:stick", "", }
-	}
-})
-
 unifieddyes.register_color_craft({
 	output = "lrfurn:sofa",
 	palette = "wallmounted",

--- a/homedecor_tables/coffeetable.lua
+++ b/homedecor_tables/coffeetable.lua
@@ -115,15 +115,6 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	output = "lrfurn:coffeetable",
-	recipe = {
-		{"", "", "", },
-		{"moreblocks:slab_wood", "moreblocks:slab_wood", "moreblocks:slab_wood", },
-		{"group:stick", "", "group:stick", }
-	}
-})
-
 if minetest.settings:get("log_mods") then
 	minetest.log("action", "[lrfurn/coffeetable] Loaded!")
 end

--- a/homedecor_tables/endtable.lua
+++ b/homedecor_tables/endtable.lua
@@ -50,15 +50,6 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
-	output = "lrfurn:endtable",
-	recipe = {
-		{"", "", "", },
-		{"moreblocks:slab_wood", "moreblocks:slab_wood", "", },
-		{"group:stick", "group:stick", "", }
-	}
-})
-
 if minetest.settings:get("log_mods") then
 	minetest.log("action", "[lrfurn/endtable] Loaded!")
 end


### PR DESCRIPTION
Remove double crafting recipes (with the same **Input** and **Output**)

How to test:
check if the items still craftable (please use moreblocks 2.xx and test it also with flux's 3.0 [PR](https://github.com/minetest-mods/moreblocks/pull/191))
List of items with modified recipes:

- homedecor:ceiling_fan
- homedecor:desk
- homedecor:desk_globe
- homedecor:desk_locked
- homedecor:dishwasher_wood
- homedecor:dryer
- homedecor:simple_bench
- homedecor:stonepath
- homedecor:swing
- homedecor:washing_machine
- lrfurn:armchair
- lrfurn:coffeetable
- lrfurn:endtable
- rfurn:longsofa
- rfurn:sofa