### PR TITLE
Fix locked items having the same craft recipe as the normal version

### DIFF
--- a/homedecor_common/inventory.lua
+++ b/homedecor_common/inventory.lua
@@ -210,7 +210,7 @@ function homedecor.handle_inventory(name, def, original_def)
 	if lockable then
 		local locked_def = table.copy(original_def)
 		locked_def.description = S("@1 (Locked)", def.description or name)
-
+		locked_def.crafts = nil
 		local locked_inventory = locked_def.inventory
 		locked_inventory.locked = true
 		locked_inventory.lockable = nil -- avoid loops of locked locked stuff


### PR DESCRIPTION
A small fix that would fix items with lockable on having the same crafting recipe for both original and the locked variant.

Example:- `homedecor:filing_cabinet` and `homedecor:filing_cabinet_locked` having the same recipe