### PR TITLE
Make half doors craftable

### DIFF
--- a/homedecor_doors_and_gates/init.lua
+++ b/homedecor_doors_and_gates/init.lua
@@ -410,8 +410,8 @@ minetest.register_craft( {
 	type = "shapeless",
 	output = "homedecor:gate_half_door_closed 4",
 	recipe = {
-		"doors:homedecor_wood_plain_a",
-		"doors:homedecor_wood_plain_a"
+		"doors:homedecor_wood_plain",
+		"doors:homedecor_wood_plain"
 	},
 })
 
@@ -419,8 +419,8 @@ minetest.register_craft( {
 	type = "shapeless",
 	output = "homedecor:gate_half_door_white_closed 4",
 	recipe = {
-		"doors:homedecor_bedroom_a",
-		"doors:homedecor_bedroom_a"
+		"doors:homedecor_basic_panel",
+		"doors:homedecor_basic_panel"
 	},
 })
 


### PR DESCRIPTION
Half doors are uncraftable because of using wrong names of doors in recipes.

Items affected: 

`homedecor:gate_half_door_closed`
`homedecor:gate_half_door_white_closed`