### PR TITLE
replace physics hell with hopefully better entity hell

### DIFF
--- a/homedecor_seating/init.lua
+++ b/homedecor_seating/init.lua
@@ -169,11 +169,21 @@ function lrfurn.sit(pos, node, clicker, itemstack, pointed_thing, seats)
 		0*math.pi/180,
 	}
 
+	local p2r_facedir = {
+		[0] = 180*math.pi/180,
+		[1] = 90*math.pi/180,
+		[2] = 0*math.pi/180,
+		[3] = 270*math.pi/180,
+	}
+
 	local entity = minetest.add_entity(sit_pos, "homedecor_seating:seat")
 	if not entity then return itemstack end --catch for when the entity fails to spawn just in case
 
 	clicker:set_attach(entity, "", {x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0}, true)
-	if string.find(node.name, "sofa") then
+	local nodedef = minetest.registered_nodes[node.name]
+	if nodedef.paramtype2 == "facedir" then
+		entity:set_rotation({x = 0, y = p2r_facedir[node.param2 % 4], z = 0})
+	elseif string.find(node.name, "sofa") then
 		entity:set_rotation({x = 0, y = p2r_sofa[node.param2 % 8], z = 0})
 	else
 		entity:set_rotation({x = 0, y = p2r[node.param2 % 8], z = 0})

--- a/homedecor_seating/init.lua
+++ b/homedecor_seating/init.lua
@@ -157,6 +157,7 @@ function lrfurn.sit(pos, node, clicker, itemstack, pointed_thing, seats)
 		0*math.pi/180,
 		0*math.pi/180,
 	}
+	p2r[0] = p2r[1]
 
 	local p2r_sofa = {
 		0*math.pi/180,
@@ -168,6 +169,7 @@ function lrfurn.sit(pos, node, clicker, itemstack, pointed_thing, seats)
 		0*math.pi/180,
 		0*math.pi/180,
 	}
+	p2r_sofa[0] = p2r_sofa[1]
 
 	local p2r_facedir = {
 		[0] = 180*math.pi/180,

--- a/homedecor_seating/init.lua
+++ b/homedecor_seating/init.lua
@@ -87,6 +87,7 @@ minetest.register_entity("homedecor_seating:seat", {
 		textures = {"blank.png", "blank.png", "blank.png", "blank.png", "blank.png", "blank.png"},
 		collisionbox = { -0.01, -0.01, -0.01, 0.01, 0.01, 0.01 },
 		selectionbox = { -0.01, -0.01, -0.01, 0.01, 0.01, 0.01, rotate = false },
+		static_save = false,
 	},
 	on_punch = function(self)
 		self.object:remove()

--- a/homedecor_seating/init.lua
+++ b/homedecor_seating/init.lua
@@ -158,11 +158,26 @@ function lrfurn.sit(pos, node, clicker, itemstack, pointed_thing, seats)
 		0*math.pi/180,
 	}
 
+	local p2r_sofa = {
+		0*math.pi/180,
+		90*math.pi/180, --correct
+		270*math.pi/180, --correct
+		180*math.pi/180, --correct
+		0*math.pi/180, --correct
+		0*math.pi/180,
+		0*math.pi/180,
+		0*math.pi/180,
+	}
+
 	local entity = minetest.add_entity(sit_pos, "homedecor_seating:seat")
 	if not entity then return itemstack end --catch for when the entity fails to spawn just in case
 
 	clicker:set_attach(entity, "", {x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0}, true)
-	entity:set_rotation({x = 0, y = p2r[node.param2 % 8], z = 0})
+	if string.find(node.name, "sofa") then
+		entity:set_rotation({x = 0, y = p2r_sofa[node.param2 % 8], z = 0})
+	else
+		entity:set_rotation({x = 0, y = p2r[node.param2 % 8], z = 0})
+	end
 
 	xcompat.player.player_attached[name] = true
     xcompat.player.set_animation(clicker, "sit", 0)

--- a/homedecor_seating/init.lua
+++ b/homedecor_seating/init.lua
@@ -94,6 +94,39 @@ minetest.register_entity("homedecor_seating:seat", {
 	end,
 })
 
+--we only care about 4 rotations, but just in case someone worldedits, etc - do something other than crash
+--radians are stupid, using degrees and then converting
+local p2r = {
+	0*math.pi/180,
+	0*math.pi/180, --correct
+	180*math.pi/180, --correct
+	90*math.pi/180, --correct
+	270*math.pi/180, --correct
+	0*math.pi/180,
+	0*math.pi/180,
+	0*math.pi/180,
+}
+p2r[0] = p2r[1]
+
+local p2r_sofa = {
+	0*math.pi/180,
+	90*math.pi/180, --correct
+	270*math.pi/180, --correct
+	180*math.pi/180, --correct
+	0*math.pi/180, --correct
+	0*math.pi/180,
+	0*math.pi/180,
+	0*math.pi/180,
+}
+p2r_sofa[0] = p2r_sofa[1]
+
+local p2r_facedir = {
+	[0] = 180*math.pi/180,
+	[1] = 90*math.pi/180,
+	[2] = 0*math.pi/180,
+	[3] = 270*math.pi/180,
+}
+
 function lrfurn.sit(pos, node, clicker, itemstack, pointed_thing, seats)
 	if not clicker:is_player() then
 		return itemstack
@@ -144,39 +177,6 @@ function lrfurn.sit(pos, node, clicker, itemstack, pointed_thing, seats)
 
 	--seat the player
 	clicker:set_pos(sit_pos)
-
-	--we only care about 4 rotations, but just in case someone worldedits, etc - do something other than crash
-	--radians are stupid, using degrees and then converting
-	local p2r = {
-		0*math.pi/180,
-		0*math.pi/180, --correct
-		180*math.pi/180, --correct
-		90*math.pi/180, --correct
-		270*math.pi/180, --correct
-		0*math.pi/180,
-		0*math.pi/180,
-		0*math.pi/180,
-	}
-	p2r[0] = p2r[1]
-
-	local p2r_sofa = {
-		0*math.pi/180,
-		90*math.pi/180, --correct
-		270*math.pi/180, --correct
-		180*math.pi/180, --correct
-		0*math.pi/180, --correct
-		0*math.pi/180,
-		0*math.pi/180,
-		0*math.pi/180,
-	}
-	p2r_sofa[0] = p2r_sofa[1]
-
-	local p2r_facedir = {
-		[0] = 180*math.pi/180,
-		[1] = 90*math.pi/180,
-		[2] = 0*math.pi/180,
-		[3] = 270*math.pi/180,
-	}
 
 	local entity = minetest.add_entity(sit_pos, "homedecor_seating:seat")
 	if not entity then return itemstack end --catch for when the entity fails to spawn just in case

--- a/homedecor_seating/mod.conf
+++ b/homedecor_seating/mod.conf
@@ -1,4 +1,4 @@
 name = homedecor_seating
 description = Homedecor mod: seating
 depends = homedecor_common
-optional_depends = screwdriver, wool, default, unifieddyes, basic_materials, player_monoids
+optional_depends = screwdriver, wool, default, unifieddyes, basic_materials


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/76fd502e-87c9-4ade-80b2-e4495a0a9767)

something something https://github.com/mt-mods/homedecor_modpack/issues/78 - see title

----------------------------

basically physics overrides suck. trying to make multiple mods play nicely with them really sucks. so in an effort to bypass the whole flaming dumpster, attaching the player to an entity that does nothing to prevent them for moving at all, regardless of what physics modifiers nightmare fuel is occuring

--------------------------------------------

* [x] armchair
* [x] sofa
* [x] longsofa
* [x] deckchair
* [x] deckchair striped blue
* [x] kitchen chair
* [x] kitchen chair padded
* [x] office chair basic
* [x] office chair upscale
* [x] simple bench