### PR TITLE
Set string in PlayerMetaRef instead of in player object attribute

### DIFF
--- a/homedecor_wardrobe/init.lua
+++ b/homedecor_wardrobe/init.lua
@@ -71,9 +71,9 @@ local function set_player_skin(player, skin, save)
 	if save and not skinsdb_mod_path then
 
 		if skin == default_skin then
-			player:set_attribute("homedecor:player_skin", "")
+			player:get_meta():set_string("homedecor:player_skin", "")
 		else
-			player:set_attribute("homedecor:player_skin", skin)
+			player:get_meta():set_string("homedecor:player_skin", skin)
 		end
 	end
 end


### PR DESCRIPTION
Replaces calls to `player:set_attribute` with `player:get_meta():set_string`.